### PR TITLE
Properly expand user directory for kernel path

### DIFF
--- a/bin/vm.py
+++ b/bin/vm.py
@@ -193,6 +193,8 @@ def get_build_path(
     kernel: Optional[str] = getattr(args, "kernel", None)
     if kernel is None:
         return None
+
+    kernel = os.path.expanduser(kernel)
     if not kernel.startswith("/") and not kernel.startswith("."):
         if script_config.builds_dir is not None:
             build_path = script_config.builds_dir / kernel


### PR DESCRIPTION
We likely want to expand any symbolic user paths before testing
whether the path to the kernel is absolute or not, otherwise we may end
up with confusing (and wrong) constructed paths:
> Traceback (most recent call last):
>   File "bin/vm.py", line 748, in <module>
>     main()
>   File "bin/vm.py", line 744, in main
>     args.func(args, get_script_config())
>   File "bin/vm.py", line 206, in cmd_run
>     qemu_args = parse_vm_config(script_config.vms_dir / args.name).qemu_args(
>   File "bin/vm.py", line 94, in qemu_args
>     newconfig = subprocess.check_output(
>   File "/usr/lib64/python3.9/subprocess.py", line 424, in check_output
>     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
>   File "/usr/lib64/python3.9/subprocess.py", line 505, in run
>     with Popen(*popenargs, **kwargs) as process:
>   File "/usr/lib64/python3.9/subprocess.py", line 951, in __init__
>     self._execute_child(args, executable, preexec_fn, close_fds,
>   File "/usr/lib64/python3.9/subprocess.py", line 1821, in _execute_child
>     raise child_exception_type(errno_num, err_msg, err_filename)
> FileNotFoundError: [Errno 2] No such file or directory: PosixPath('/home/<user>/local/src/bpf-next/tools/testing/selftests/bpf/~/local/opt/linux-build/default')