### PR TITLE
vm.py: Remove now-unnecessary listnewconfig check

### DIFF
--- a/bin/vm.py
+++ b/bin/vm.py
@@ -91,13 +91,6 @@ class VMConfig:
 
         # Command-line arguments.
         if build_path is not None:
-            newconfig = subprocess.check_output(
-                ["make", "-s", "listnewconfig"], cwd=build_path, universal_newlines=True
-            ).strip()
-            if newconfig:
-                sys.exit(
-                    "Kernel build .config is not up to date; cannot determine image name"
-                )
             image_name = subprocess.check_output(
                 ["make", "-s", "image_name"], cwd=build_path, universal_newlines=True
             ).strip()


### PR DESCRIPTION
Depending on which compiler you use to build the kernel, it will change
the kernels' .config file. For example, gcc will have
CONFIG_GCC_PLUGINS=y in the .config, whereas clang will have
CONFIG_CC_IS_CLANG=y.

The implication is that if you compile the kernel with e.g. clang, then
make -s listnewconfig will give you the following non-empty output:

$ make -s listnewconfig
CONFIG_X86_X32_ABI=n
CONFIG_GCC_PLUGINS=y
CONFIG_GCC_PLUGIN_LATENT_ENTROPY=n
CONFIG_GCC_PLUGIN_STACKLEAK=n
CONFIG_RANDSTRUCT_PERFORMANCE=n
CONFIG_READABLE_ASM=n
CONFIG_DEBUG_SECTION_MISMATCH=n
[void@maniforge bpf-next]$ vim .config

even if the .config hasn't actually changed. This will cause vm.py run
to fail, because it checks to make sure that listnewconfig is empty to
ensure that you're not running a stale kernel build.

With commit 993bdde94547 ("kbuild: add image_name to
no-sync-config-targets"), 'make image_name' no longer resyncs Kconfig.
This means that the make listnewconfig check is no longer really
necessary, so we can just remove it to avoid the above issue.

Signed-off-by: David Vernet <void@manifault.com>