### PR TITLE
vm.py: Add bpftrace and bcc to default arch packages

### DIFF
--- a/bin/vm.py
+++ b/bin/vm.py
@@ -533,6 +533,8 @@ def cmd_archinstall(args: argparse.Namespace, script_config: ScriptConfig) -> No
         "python",
         "strace",
         "vim",
+        "bpftrace",
+        "bcc",
         # xfstests
         "attr",
         "bc",


### PR DESCRIPTION
cmd_install() specifies a list of default arch packages that are installed when installing arch onto a VM. These packages contain non-critical but useful packages such as gcc, git, perf, etc.

Let's add bpftrace and bcc as well, which can be useful for diagnosing bugs in kernels.